### PR TITLE
Add a jekyll-container folder

### DIFF
--- a/jekyll-container/Containerfile
+++ b/jekyll-container/Containerfile
@@ -1,0 +1,14 @@
+FROM ruby:2-alpine as jekyll
+
+RUN apk add --no-cache build-base gcc bash cmake git gcompat
+
+# install both bundler 1.x and 2.x incase you're running
+# old gem files
+# https://bundler.io/guides/bundler_2_upgrade.html#faq
+RUN gem install bundler -v "~>1.0" && gem install bundler jekyll jekyll-paginate just-the-docs
+
+EXPOSE 4000
+
+WORKDIR /site
+
+ENTRYPOINT [ "bash" ]

--- a/jekyll-container/README.md
+++ b/jekyll-container/README.md
@@ -1,0 +1,11 @@
+# Build
+buildah bud --format docker -f Containerfile -t jekyll
+
+# Run
+podman run -it --net=host -v $(pwd):/site:z localhost/jekyll
+
+Then run 'make serve' from the /site folder.
+
+# Browse
+http://127.0.0.1:4000/
+


### PR DESCRIPTION
This way we can all build the same container and use the same stuff.
Instructions are in the README
