### PR TITLE
Add an acm-import role

### DIFF
--- a/acm_import/README.md
+++ b/acm_import/README.md
@@ -1,0 +1,10 @@
+# Playbook and role to automatically import clusters in ACM
+
+Just export `HUBCONFIG` pointing to the hub/acm cluster and `REGIONCONFIG` pointing to the regional cluster.
+
+Then run:
+`ansible-playbook ./post.yml`
+
+After a minute or two the cluster will be imported on the hub.
+
+By default it adds the 'clusterGroup=region-one' label. This can be customized with -e clustergroup='foo'

--- a/acm_import/post.yml
+++ b/acm_import/post.yml
@@ -1,0 +1,28 @@
+---
+- name: Importing ACM clusters automatically
+  hosts: localhost
+  connection: local
+  pre_tasks:
+  - name: Set HUBCONFIG and REGIONCONFIG facts from env variables
+    set_fact:
+      HUBCONFIG: "{{ lookup('env', 'HUBCONFIG') }}"
+      REGIONCONFIG: "{{ lookup('env', 'REGIONCONFIG') }}"
+
+  - name: Check for correct HUBCONFIG env variable
+    fail:
+      msg: "HUBCONFIG env variable needs to be set and pointing to the HUB kubeconfig file"
+    when:
+      HUBCONFIG is not defined or HUBCONFIG | length == 0
+
+  - name: Check for correct REGIONCONFIG env variable
+    fail:
+      msg: "REGIONCONFIG env variable needs to be set and pointing to the REGION kubeconfig file"
+    when:
+      REGIONCONFIG is not defined or REGIONCONFIG | length == 0
+
+  - name: Print the hub and regional kubeconfigs
+    debug:
+      msg: "HUBCONFIG: {{ HUBCONFIG }} - REGIONCONFIG: {{ REGIONCONFIG }}"
+
+  roles:
+    - acm_import

--- a/acm_import/roles/acm_import/defaults/main.yml
+++ b/acm_import/roles/acm_import/defaults/main.yml
@@ -1,0 +1,7 @@
+clustergroup: region-one
+ocm_iam_policy_controller: true
+ocm_search_controller: true
+ocm_policy_controller: true
+ocm_cert_policy_controller: true
+ocm_application_manager: true
+ocm_argo_cd_cluster: false

--- a/acm_import/roles/acm_import/meta/main.yml
+++ b/acm_import/roles/acm_import/meta/main.yml
@@ -1,0 +1,2 @@
+collections:
+  - kubernetes.core

--- a/acm_import/roles/acm_import/tasks/hub-acm-add-regional-cluster.yml
+++ b/acm_import/roles/acm_import/tasks/hub-acm-add-regional-cluster.yml
@@ -1,0 +1,80 @@
+- name: "Verify valid cluster name"
+  assert:
+    that: region_cluster_name is regex('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    fail_msg: "region_cluster_name failed regex validation"
+    success_msg: "{{ region_cluster_name }} is valid"
+
+- name: "Check if ManagedCluster is registered"
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ HUBCONFIG }}"
+    api_version: cluster.open-cluster-management.io/v1
+    kind: ManagedCluster
+    name: "{{ region_cluster_name }}"
+  register: ocm_mc_obj
+
+- name: "Set fact if regional cluster is registered"
+  set_fact:
+    ocm_mc_registered: "{{ ocm_mc_obj.resources | length == 1 }}"
+
+- name: Register Managed Cluster
+  block:
+    - name: "Create regional ManagedCluster"
+      kubernetes.core.k8s:
+        state: present
+        kubeconfig: "{{ HUBCONFIG }}"
+        template: managedcluster.yml.j2
+        wait: true
+        wait_condition:
+          type: 'HubAcceptedManagedCluster'
+          reason: 'HubClusterAdminAccepted'
+          status: 'True'
+        wait_timeout: 60
+
+    - name: "Create regional KlusterAddonConfig"
+      kubernetes.core.k8s:
+        state: present
+        kubeconfig: "{{ HUBCONFIG }}"
+        template: klusterletaddonconfig.yml.j2
+  when:
+    - not ocm_mc_registered
+
+- name: "Pull ManagedClusterJoined Status"
+  set_fact:
+    ocm_mc_status: "{{ lookup('kubernetes.core.k8s', kubeconfig=HUBCONFIG, api_version='cluster.open-cluster-management.io/v1', kind='ManagedCluster', resource_name=region_cluster_name) | json_query(query) }}"
+  vars:
+    query: "status.conditions[?type == 'ManagedClusterJoined'].status"
+
+- name: "Determine if Managed Cluster has Joined"
+  set_fact:
+    ocm_mc_reported: "{{ ocm_mc_status | length == 1 and ocm_mc_status[0] == 'True' }}"
+
+- name: Attach Managed Cluster
+  block:
+    - name: "[HUB] Derive import name"
+      set_fact:
+        cluster_import: "{{ region_cluster_name }}-import"
+
+    - name: "[HUB] Get CRDs from Hub for the new ManagedCluster"
+      set_fact:
+        import_crds: "{{ lookup('k8s', kubeconfig=HUBCONFIG, api_version='v1', kind='Secret', namespace=region_cluster_name, resource_name=cluster_import) | json_query(query) }}"
+      vars:
+        query: "data.\"crds.yaml\""
+
+    - name: "[HUB] Get ROs from Hub for the new ManagedCluster"
+      set_fact:
+        import_ros: "{{ lookup('k8s', kubeconfig=HUBCONFIG, api_version='v1', kind='Secret', namespace=region_cluster_name, resource_name=cluster_import) | json_query(query) }}"
+      vars:
+        query: "data.\"import.yaml\""
+
+    - name: "[MC] Apply CRDs to new ManagedCluster"
+      kubernetes.core.k8s:
+        state: present
+        kubeconfig: "{{ REGIONCONFIG }}"
+        definition: "{{ import_crds | b64decode }}"
+
+    - name: "[MC] Apply ROs to new ManagedCluster"
+      kubernetes.core.k8s:
+        state: present
+        kubeconfig: "{{ REGIONCONFIG }}"
+        definition: "{{ import_ros | b64decode }}"
+  when: not ocm_mc_reported

--- a/acm_import/roles/acm_import/tasks/main.yml
+++ b/acm_import/roles/acm_import/tasks/main.yml
@@ -1,0 +1,10 @@
+- name: Fetch regional cluster info
+  include_tasks:
+    file: region-fetch-api.yml
+    apply:
+      environment:
+        KUBECONFIG: "{{ REGIONCONFIG }}"
+
+- name: Add the regional cluster to the ACM hub
+  include_tasks:
+    file: hub-acm-add-regional-cluster.yml

--- a/acm_import/roles/acm_import/tasks/region-fetch-api.yml
+++ b/acm_import/roles/acm_import/tasks/region-fetch-api.yml
@@ -1,0 +1,40 @@
+- name: Fetch API endpoint of regional cluster
+  kubernetes.core.k8s_cluster_info:
+  register: cluster_info
+
+- name: Set regional api fact
+  set_fact:
+    region_api: "{{ cluster_info['connection']['host'] }}"
+
+# FIXME(bandini): This currently seems the sanest way to be sure of the cluster name being used as k8s has no concept
+# of own cluster name and other hacks like parsing the API url seem worse than this
+- name: Find regional cluster name
+  shell: |
+    {% raw %}
+    oc config view --raw -o go-template="{{ range .clusters }}{{ if eq .cluster.server \"${API}\" }}{{ .name }}{{ end }}{{ end }}"
+    {% endraw %}
+  register: region_cluster_oc
+  changed_when: false
+  environment:
+    API: "{{ region_api }}"
+
+- name: Set regional cluster name fact
+  set_fact:
+    region_cluster_name: "{{ region_cluster_oc.stdout }}"
+  failed_when: region_cluster_oc.stdout | length == 0
+
+# This is strictly not needed but could be useful eventually
+- name: Find regional CA
+  shell: |
+    {% raw %}
+    oc config view --raw -o go-template="{{ range .clusters }}{{ if eq .cluster.server \"${API}\" }}{{ index .cluster \"certificate-authority-data\" }}{{ end }}{{ end }}"
+    {% endraw %}
+  register: region_cluster_ca
+  changed_when: false
+  environment:
+    API: "{{ region_api }}"
+
+- name: Set regional CA fact
+  set_fact:
+    region_ca: "{{ region_cluster_ca.stdout }}"
+  failed_when: region_cluster_ca.stdout | length == 0

--- a/acm_import/roles/acm_import/templates/klusterletaddonconfig.yml.j2
+++ b/acm_import/roles/acm_import/templates/klusterletaddonconfig.yml.j2
@@ -1,0 +1,26 @@
+---
+apiVersion: agent.open-cluster-management.io/v1
+kind: KlusterletAddonConfig
+metadata:
+  name: {{ region_cluster_name }}
+  namespace: {{ region_cluster_name }}
+spec:
+  clusterName: {{ region_cluster_name }}
+  clusterNamespace: {{ region_cluster_name }}
+  clusterLabels:
+    cloud: auto-detect
+    name: {{ region_cluster_name }}
+    vendor: auto-detect
+    clusterGroup: {{ clustergroup }}
+  iamPolicyController:
+    enabled: {{ ocm_iam_policy_controller }}
+  searchCollector:
+    enabled: {{ ocm_search_controller }}
+  policyController:
+    enabled: {{ ocm_policy_controller }}
+  certPolicyController:
+    enabled: {{ ocm_cert_policy_controller }}
+  applicationManager:
+    enabled: {{ ocm_application_manager }}
+    argocdCluster: {{ ocm_argo_cd_cluster }}
+...

--- a/acm_import/roles/acm_import/templates/managedcluster.yml.j2
+++ b/acm_import/roles/acm_import/templates/managedcluster.yml.j2
@@ -1,0 +1,14 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: {{ region_cluster_name }}
+  labels:
+    name: {{ region_cluster_name }}
+    vendor: auto-detect
+    cloud: auto-detect
+    clusterGroup: {{ clustergroup }}
+spec:
+  hubAcceptsClient: true
+  leaseDurationSeconds: 60
+...


### PR DESCRIPTION
This avoids having to import the cluster by clicking around in the ACM
UI.

Just export `HUBCONFIG` pointing to the hub/acm cluster and `REGIONCONFIG` pointing to the regional cluster.

Then run:
`ansible-playbook ./post.yml`
