### PR TITLE
Add an asciidoctor script to /usr/local/bin

### DIFF
--- a/homepage-container/Containerfile
+++ b/homepage-container/Containerfile
@@ -3,6 +3,7 @@ FROM --platform=$BUILDPLATFORM alpine:3.17 as build
 RUN apk add --no-cache hugo build-base gcc bash cmake git gcompat curl ruby
 RUN curl https://htmltest.wjdp.uk | bash -s -- -b /usr/local/bin
 RUN gem install bundler && echo -e 'source "https://rubygems.org"\ngem "asciidoctor"\n' > Gemfile && bundle install
+COPY asciidoctor /usr/local/bin/asciidoctor
 EXPOSE 4000
 
 WORKDIR /site

--- a/homepage-container/asciidoctor
+++ b/homepage-container/asciidoctor
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+ad="/usr/bin/asciidoctor"
+
+$ad --trace --verbose \
+  --no-header-footer \
+  --attribute experimental=true
+  --attribute icons=font \
+  -


### PR DESCRIPTION
/usr/local/bin precedes /usr/bin so we create an asciidoctor wrapper
to control which options are used as hugo invokes only 'asciidoctor'
without any parameters.

See
https://blog.arkey.fr/2020/04/23/tackling-hugo-integration-of-asciidoctor/
for potential future improvements
