### PR TITLE
Drop OCP 4.8 support for MCG and IE

### DIFF
--- a/ci-triggers/industrial-edge.yaml
+++ b/ci-triggers/industrial-edge.yaml
@@ -13,7 +13,6 @@ triggers:
     - '4.11'
     - '4.10'
     - '4.9'
-    - '4.8'
 
   openshift:
   - version: '4.12'
@@ -34,11 +33,6 @@ triggers:
     branch: 'v2.3'
     platforms:
       - aws
-    buildType: stable
-  - version: '4.8'
-    branch: 'v2.3'
-    platforms:
-      - gcp
     buildType: stable
 
   subscriptions:

--- a/ci-triggers/multicloud-gitops.yaml
+++ b/ci-triggers/multicloud-gitops.yaml
@@ -13,7 +13,6 @@ triggers:
   - name: 'v1.0'
     versions:
     - '4.9'
-    - '4.8'
 
   openshift:
   - version: '4.12'
@@ -34,11 +33,6 @@ triggers:
     branch: 'v1.0'
     platforms:
       - aws
-    buildType: stable
-  - version: '4.8'
-    branch: 'v1.0'
-    platforms:
-      - gcp
     buildType: stable
 
   subscriptions:


### PR DESCRIPTION
https://access.redhat.com/support/policy/updates/openshift 4.8 support
is over, so let's drop it now. Technically ELS support lasts until
Apr 27, 2023 but I suspect it is okay to drop it at this point.
