### PR TITLE
Removed support for openshift 4.9 for Industrial Edge

### DIFF
--- a/ci-triggers/industrial-edge.yaml
+++ b/ci-triggers/industrial-edge.yaml
@@ -12,7 +12,6 @@ triggers:
     versions:
     - '4.11'
     - '4.10'
-    - '4.9'
 
   openshift:
   - version: '4.12'
@@ -28,11 +27,6 @@ triggers:
     branch: 'v2.3'
     platforms:
       - azure
-    buildType: stable
-  - version: '4.9'
-    branch: 'v2.3'
-    platforms:
-      - aws
     buildType: stable
 
   subscriptions:


### PR DESCRIPTION
- Removed support for OpenShift 4.9 which will be unsupported by April 18,2023