### PR TITLE
Upgrade super-linter to v8.5.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
 

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -2,6 +2,8 @@ name: Ansible Lint # feel free to pick your own name
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -10,7 +12,7 @@ jobs:
 
     steps:
       # Important: This sets up your GITHUB_WORKSPACE environment variable
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@
 name: Docker build and push to quay
 
 # Runs on both PR and push gh actions, but only pushes the image when it is a gh push action
-permissions: read-all
+permissions: read-all # zizmor: ignore[excessive-permissions]
 
 on:
   push:
@@ -33,12 +33,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -65,7 +65,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Debug
-        uses: hmarr/debug-action@v3
+        uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820 # v3
 
       - name: Test bandini
         run: |

--- a/.github/workflows/homepage-container.yml
+++ b/.github/workflows/homepage-container.yml
@@ -11,7 +11,7 @@ on:
       - '.github/workflows/homepage-container.yml'
   workflow_call:
 
-permissions: read-all
+permissions: read-all # zizmor: ignore[excessive-permissions]
 
 jobs:
   podman-build:
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -3,6 +3,8 @@ name: Super linter
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   build:
     # Name the Job
@@ -12,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
@@ -22,7 +24,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v8
+        uses: super-linter/super-linter/slim@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8.5.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -46,3 +48,9 @@ jobs:
           VALIDATE_TRIVY: false
           VALIDATE_YAML: false
           VALIDATE_YAML_PRETTIER: false
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
+          VALIDATE_SPELL_CODESPELL: false
+          VALIDATE_JSON_PRETTIER: false
+          VALIDATE_PYTHON_PYINK: false
+          VALIDATE_PYTHON_RUFF_FORMAT: false

--- a/aws-tools/lambda/stopinstances.py
+++ b/aws-tools/lambda/stopinstances.py
@@ -5,7 +5,8 @@ regions = ["us-west-1", "us-west-2", "us-east-1", "us-east-2"]
 
 # Dictionary that holds the key/value pair for each region
 # key = key e.g. 'us-west-1'
-# value = array e.g. ['i-003cf2aedc58219bf', 'i-0852da9f9b599e873', 'i-06b7b658e21e5e726', 'i-00fa6d35fea24c33b', 'i-0f5746bb760cab75b', 'i-021ec39d1d4bf6c7e']
+# value = array e.g. ['i-003cf2aedc58219bf', 'i-0852da9f9b599e873',
+#   'i-06b7b658e21e5e726', 'i-00fa6d35fea24c33b']
 allInstances = {}
 
 # Array of instances that are running for a region and we want to stop


### PR DESCRIPTION
- Pin super-linter to v8.5.0 (SHA 61abc07d)
- Pin all GitHub Actions to SHA references
- Add persist-credentials: false to checkout steps
- Add permissions: read-all to workflow files
- Add dependabot cooldown and grouping configuration
- Disable new v8 linters not applicable to this repo
- Add FILTER_REGEX_EXCLUDE for nested .github directories
- Add zizmor ignore comments for reusable workflow refs
- Update markdownlint config for new rules
- Migrate ansible-lint-action to ansible/ansible-lint

